### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ A Model Context Protocol (MCP) server that provides access to the Tatum Blockcha
 
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=tatumio&config=eyJjb21tYW5kIjoibnB4IEB0YXR1bWlvL2Jsb2NrY2hhaW4tbWNwIiwiZW52Ijp7IlRBVFVNX0FQSV9LRVkiOiJZT1VSX0FQSV9LRVkifX0%3D)
 
+<a href="https://glama.ai/mcp/servers/@tatumio/tatum-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tatumio/tatum-mcp/badge" alt="Tatum Server MCP server" />
+</a>
+
 ## 🚀 Features
 
 - **130+ Blockchain Networks**: Bitcoin, Ethereum, Solana, Polygon, Arbitrum, Base, Avalanche, and many more.


### PR DESCRIPTION
This PR adds a badge for the [Tatum MCP Server](https://glama.ai/mcp/servers/@tatumio/tatum-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@tatumio/tatum-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tatumio/tatum-mcp/badge" alt="Tatum Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.