### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,8 @@ Tatum is a blockchain development platform that provides APIs, SDKs, and tools f
 ---
 
 **Made with ❤️ by the Tatum team**
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/tatumio-blockchain-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/tatumio-blockchain-mcp).